### PR TITLE
fix(api): Add missing anthropic-version header for generate stream

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -111,6 +111,7 @@ async function callAnthropic(baseUrl, apiKey, model, messages, onChunk) {
     headers: {
       'Content-Type': 'application/json',
       'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
     },
     body: JSON.stringify({
       model,


### PR DESCRIPTION
Thanks for this amazing open-source project!

I found that when using the Anthropic provider, the chart generation fails with a `400 invalid_request_error` because the `anthropic-version` header is missing in the `/api/generate` request stream.

This PR adds the required `anthropic-version: '2023-06-01'` header to the `callAnthropic` function, which fixes the issue.

Error log:
```
Anthropic API error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"anthropic-version: header is required"}}
```

为这个优秀的项目点赞！