### PR TITLE
Docker 容器化与端口改为 30055；修复 compose/nginx/deploy；添加 .gitattributes 统一 LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+*.sh text eol=lf
+Dockerfile text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.conf text eol=lf
+*.mjs text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# 使用官方 Node.js 运行时作为基础镜像（Debian slim，规避 alpine 拉取问题）
+FROM node:20-slim AS base
+
+# 设置工作目录
+WORKDIR /app
+
+# 安装 pnpm
+RUN npm install -g pnpm
+
+# 复制包管理文件
+COPY package.json pnpm-lock.yaml ./
+
+# 安装依赖
+RUN pnpm install --frozen-lockfile
+
+# 复制源代码
+COPY . .
+
+# 构建应用
+RUN pnpm build
+
+# 生产阶段（使用 Debian slim）
+FROM node:20-slim AS production
+
+# 安装 pnpm
+RUN npm install -g pnpm
+
+# 设置工作目录
+WORKDIR /app
+
+# 安装运行时工具（用于健康检查）
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
+# 复制 package.json 和 pnpm-lock.yaml
+COPY package.json pnpm-lock.yaml ./
+
+# 安装生产依赖
+RUN pnpm install --frozen-lockfile --production
+
+# 复制构建产物
+COPY --from=base /app/.next ./.next
+COPY --from=base /app/public ./public
+COPY --from=base /app/next.config.mjs ./
+
+# 使用镜像内置的 node 非 root 用户
+RUN chown -R node:node /app
+USER node
+
+# 暴露端口
+EXPOSE 30055
+
+# 设置环境变量
+ENV NODE_ENV=production
+ENV PORT=30055
+
+# 启动应用
+CMD ["pnpm", "start"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# ===============================
+# Smart Excalidraw Docker 部署脚本
+# ===============================
+
+set -e
+
+echo "🚀 Smart Excalidraw Docker 部署脚本"
+echo "======================================="
+
+# 检查 Docker 和 Docker Compose
+if ! command -v docker &> /dev/null; then
+    echo "❌ 错误: Docker 未安装"
+    echo "请先安装 Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null; then
+    echo "❌ 错误: Docker Compose 未安装"
+    echo "请先安装 Docker Compose: https://docs.docker.com/compose/install/"
+    exit 1
+fi
+
+# 设置默认变量
+PROJECT_NAME="smart-excalidraw"
+ENV_FILE=".env"
+USE_NGINX="false"
+
+# 解析命令行参数
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --nginx)
+            USE_NGINX="true"
+            shift
+            ;;
+        --env)
+            ENV_FILE="$2"
+            shift 2
+            ;;
+        --project)
+            PROJECT_NAME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "用法: $0 [选项]"
+            echo "选项:"
+            echo "  --nginx      使用 nginx 反向代理"
+            echo "  --env FILE   指定环境变量文件 (默认: .env)"
+            echo "  --project    指定项目名称"
+            echo "  -h, --help   显示此帮助信息"
+            exit 0
+            ;;
+        *)
+            echo "未知选项: $1"
+            echo "使用 -h 或 --help 查看帮助"
+            exit 1
+            ;;
+    esac
+done
+
+echo "📋 部署配置:"
+echo "  项目名称: $PROJECT_NAME"
+echo "  环境变量: $ENV_FILE"
+echo "  使用 nginx: $USE_NGINX"
+echo ""
+
+# 检查环境变量文件
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "⚠️  警告: 环境变量文件 $ENV_FILE 不存在"
+    echo "创建默认的 .env 文件..."
+    cp .env.example .env
+    echo "请编辑 .env 文件并配置必要的环境变量"
+    echo ""
+    read -p "是否继续部署? (y/N): " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "部署已取消"
+        exit 0
+    fi
+fi
+
+# 拉取最新代码（如果是 Git 仓库）
+if [[ -d "../.git" ]]; then
+    echo "📥 拉取最新代码..."
+    cd ..
+    git pull
+    cd smart-excalidraw-docker
+fi
+
+# 创建环境变量文件
+if [[ -f "../.env.example" ]]; then
+    echo "📄 复制环境变量文件..."
+    cp ../.env.example ../.env
+fi
+
+# 停止并删除现有容器
+echo "🛑 停止现有容器..."
+docker-compose down
+
+# 构建并启动服务
+echo "🔨 构建 Docker 镜像..."
+docker-compose build --no-cache
+
+echo "🚀 启动服务..."
+if [[ "$USE_NGINX" == "true" ]]; then
+    docker-compose --profile nginx up -d
+    echo "✅ 服务已启动 (端口: 80/443)"
+else
+    docker-compose up -d
+    echo "✅ 服务已启动 (端口: 30055)"
+fi
+
+# 等待服务启动
+echo "⏳ 等待服务启动..."
+sleep 10
+
+# 检查服务状态
+echo "🔍 检查服务状态..."
+if docker-compose ps | grep -q "Up"; then
+    echo "✅ 服务运行正常!"
+    
+    if [[ "$USE_NGINX" == "true" ]]; then
+        echo "🌐 访问地址: http://localhost"
+    else
+        echo "🌐 访问地址: http://localhost:30055"
+    fi
+    
+    echo "📊 查看日志: docker-compose logs -f"
+    echo "🛑 停止服务: docker-compose down"
+else
+    echo "❌ 服务启动失败，请检查日志:"
+    echo "   docker-compose logs"
+    exit 1
+fi
+
+echo ""
+echo "🎉 部署完成!"
+echo "📖 更多配置请查看 README.md"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  smart-excalidraw:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: smart-excalidraw-app
+    restart: unless-stopped
+    ports:
+      - "30055:30055"
+    environment:
+      # 应用环境变量
+      - NODE_ENV=production
+      - PORT=30055
+      
+      # 服务器端 LLM 配置（可选）
+      # 如果要使用服务器端 LLM，取消注释并配置以下变量
+      # - ACCESS_PASSWORD=your-secure-password
+      # - SERVER_LLM_TYPE=anthropic  # 或 openai
+      # - SERVER_LLM_BASE_URL=https://api.anthropic.com/v1
+      # - SERVER_LLM_API_KEY=sk-ant-your-key-here
+      # - SERVER_LLM_MODEL=claude-sonnet-4-5-20250929
+      
+      # 性能优化
+      - NODE_OPTIONS=--max-old-space-size=4096
+    volumes:
+      []
+    networks:
+      - smart-excalidraw-network
+    
+    # 健康检查
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:30055/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # 可选：使用 nginx 作为反向代理
+  # nginx:
+  #   image: nginx:alpine
+  #   container_name: smart-excalidraw-nginx
+  #   restart: unless-stopped
+  #   ports:
+  #     - "80:80"
+  #     - "443:443"
+  #   volumes:
+  #     - ./nginx.conf:/etc/nginx/nginx.conf:ro
+  #     - ./ssl:/etc/nginx/ssl:ro
+  #   depends_on:
+  #     - smart-excalidraw
+  #   networks:
+  #     - smart-excalidraw-network
+
+networks:
+  smart-excalidraw-network:
+    driver: bridge
+
+# 可选：数据卷配置（如果需要持久化数据）
+# volumes:
+#   logs:
+#   uploads:

--- a/dockerignore
+++ b/dockerignore
@@ -1,0 +1,117 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Production build
+.next
+dist
+build
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Documentation
+README.md
+README_EN.md
+docs
+*.md
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+docker-compose.*.yml
+
+# CI/CD
+.github
+.gitlab-ci.yml
+.travis.yml
+.circleci
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# ESLint cache
+.eslintcache
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Storybook build outputs
+.out
+.storybook-out
+
+# Temporary folders
+tmp
+temp
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,108 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # 日志格式
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                   '$status $body_bytes_sent "$http_referer" '
+                   '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    # 性能优化
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    client_max_body_size 20M;
+
+    # Gzip 压缩
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/xml+rss
+        application/json
+        application/xml
+        application/rss+xml
+        application/atom+xml
+        image/svg+xml;
+
+    # 上游服务器配置
+    upstream smart_excalidraw {
+        server smart-excalidraw:30055;
+        keepalive 32;
+    }
+
+    # HTTP 服务器配置
+    server {
+        listen 80;
+        server_name _;
+
+        # 重定向到 HTTPS（如果需要 SSL）
+        # return 301 https://$server_name$request_uri;
+
+        # 代理到 Next.js 应用
+        location / {
+            proxy_pass http://smart_excalidraw;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+            
+            # 超时设置
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+        }
+
+        # 静态文件缓存
+        location /_next/static {
+            proxy_pass http://smart_excalidraw;
+            proxy_cache_valid 200 1d;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
+        # 静态资源缓存
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            proxy_pass http://smart_excalidraw;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # 健康检查
+        location /health {
+            proxy_pass http://smart_excalidraw;
+            access_log off;
+        }
+    }
+
+    # HTTPS 服务器配置（如果需要 SSL）
+    # server {
+    #     listen 443 ssl http2;
+    #     server_name your-domain.com;
+    #
+    #     ssl_certificate /etc/nginx/ssl/cert.pem;
+    #     ssl_certificate_key /etc/nginx/ssl/key.pem;
+    #     ssl_protocols TLSv1.2 TLSv1.3;
+    #     ssl_ciphers HIGH:!aNULL:!MD5;
+    #     ssl_prefer_server_ciphers on;
+    #
+    #     # ... 代理配置与 HTTP 相同
+    # }
+}


### PR DESCRIPTION
- 变更摘要
- 切换基础镜像到 node:20-slim ，用 apt-get 安装 curl ，使用非 root node 用户。
- 统一服务端口为 30055 （Docker、Nginx、deploy 脚本一致）。
- 修复 docker-compose.yml 的 volumes 数组语法，移除废弃的 version 字段。
- 新增/完善 .gitattributes ，强制脚本与配置文件使用 LF，避免 Windows CRLF 造成容器执行问题。
- （如已完成）将 dockerignore 重命名为 .dockerignore ，确保忽略规则生效。
- 具体文件改动
- Dockerfile：基础镜像、包安装、用户、暴露端口。
- docker-compose.yml：端口映射 30055:30055 、健康检查。
- nginx.conf：上游与监听端口改为 30055 。
- deploy.sh：端口与运行指令同步为 30055 。
- .gitattributes：统一行结尾为 LF。
- （可选）README/README_EN：端口说明由 3000 调整为 30055 （如适用；原仓库文档默认端口为 3000 [0]）。
- 兼容性与风险
- 不影响前端逻辑；部署端口从 3000 改为 30055 ，需同步文档与反向代理配置。
- Windows 环境下 Docker 可能遇到 Node 基础镜像拉取失败（unexpected EOF/size validation），建议配置镜像加速与 DNS 后重试。
- 测试步骤（Windows）
- 拉取基础镜像（若能正常拉取）：
  ```
  docker pull node:20-slim
  ```
- Docker Compose 构建并启动：
  ```
  docker compose up -d --build
  ```
- 访问应用：打开 http://localhost:30055
- 查看容器状态与日志：
  ```
  docker compose ps
  ```
  ```
  docker compose logs -f 
  smart-excalidraw
  ```
- 其他
- 若面向上游仓库提交，端口变更可说明为“便于本地/生产统一”，也可改为通过环境变量控制，避免强制变更默认行为。
- 许可证保持 MIT，不修改版权信息。