### PR TITLE
feat(config): 添加阿里云百炼作为新模型提供商选项

### DIFF
--- a/components/ConfigManager.jsx
+++ b/components/ConfigManager.jsx
@@ -524,6 +524,7 @@ function ConfigEditor({ config, isCreating, onSave, onCancel }) {
             >
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
+              <option value="aliyun">阿里云百炼</option>
             </select>
           </div>
 
@@ -535,7 +536,12 @@ function ConfigEditor({ config, isCreating, onSave, onCancel }) {
               type="text"
               value={formData.baseUrl}
               onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
-              placeholder={formData.type === 'openai' ? 'https://api.openai.com/v1' : 'https://api.anthropic.com/v1'}
+              placeholder={
+                formData.type === 'openai' ? 'https://api.openai.com/v1' : 
+                formData.type === 'anthropic' ? 'https://api.anthropic.com/v1' :
+                formData.type === 'aliyun' ? 'https://dashscope.aliyuncs.com/compatible-mode/v1' :
+                'https://api.example.com/v1'
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
             />
           </div>

--- a/components/ConfigModal.jsx
+++ b/components/ConfigModal.jsx
@@ -150,6 +150,7 @@ export default function ConfigModal({ isOpen, onClose, onSave, initialConfig, sh
             >
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
+              <option value="aliyun">阿里云百炼</option>
             </select>
           </div>
 
@@ -162,7 +163,12 @@ export default function ConfigModal({ isOpen, onClose, onSave, initialConfig, sh
               type="text"
               value={config.baseUrl}
               onChange={(e) => setConfig({ ...config, baseUrl: e.target.value })}
-              placeholder={config.type === 'openai' ? 'https://api.openai.com/v1' : 'https://api.anthropic.com/v1'}
+              placeholder={
+                config.type === 'openai' ? 'https://api.openai.com/v1' : 
+                config.type === 'anthropic' ? 'https://api.anthropic.com/v1' :
+                config.type === 'aliyun' ? 'https://dashscope.aliyuncs.com/compatible-mode/v1' :
+                'https://api.example.com/v1'
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-900"
             />
           </div>

--- a/lib/config-manager.js
+++ b/lib/config-manager.js
@@ -247,8 +247,8 @@ class ConfigManager {
       errors.push('配置名称不能为空');
     }
 
-    if (!config.type || !['openai', 'anthropic'].includes(config.type)) {
-      errors.push('配置类型必须是 openai 或 anthropic');
+    if (!config.type || !['openai', 'anthropic', 'aliyun'].includes(config.type)) {
+      errors.push('配置类型必须是 openai、anthropic 或 aliyun');
     }
 
     if (!config.baseUrl || config.baseUrl.trim() === '') {

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -16,6 +16,8 @@ export async function callLLM(config, messages, onChunk) {
     return callOpenAI(baseUrl, apiKey, model, messages, onChunk);
   } else if (type === 'anthropic') {
     return callAnthropic(baseUrl, apiKey, model, messages, onChunk);
+  } else if (type === 'aliyun') {
+    return callAliyunBailian(baseUrl, apiKey, model, messages, onChunk);
   } else {
     throw new Error(`Unsupported provider type: ${type}`);
   }
@@ -240,6 +242,47 @@ function processMessageForAnthropic(message) {
 }
 
 /**
+ * Call Aliyun Bailian API (OpenAI-compatible)
+ */
+async function callAliyunBailian(baseUrl, apiKey, model, messages, onChunk) {
+  // 阿里云百炼使用OpenAI兼容的API格式
+  const url = `${baseUrl}/chat/completions`;
+
+  // Process messages to support multimodal content (text + images)
+  const processedMessages = messages.map(processMessageForAliyun);
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: processedMessages,
+      stream: true,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Aliyun Bailian API error: ${response.status} ${error}`);
+  }
+
+  return processOpenAIStream(response.body, onChunk);
+}
+
+/**
+ * Process message for Aliyun Bailian API (OpenAI-compatible format)
+ * @param {Object} message - Message object
+ * @returns {Object} Processed message for Aliyun Bailian
+ */
+function processMessageForAliyun(message) {
+  // 阿里云百炼使用OpenAI兼容格式
+  return processMessageForOpenAI(message);
+}
+
+/**
  * Test configuration connection with a simple API call
  * @param {Object} config - Provider configuration
  * @returns {Promise<Object>} Test result with success status and message
@@ -305,6 +348,26 @@ export async function fetchModels(type, baseUrl, apiKey) {
       headers: {
         'x-api-key': apiKey,
         'anthropic-version': '2023-06-01',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch models: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return (Array.isArray(data?.data) ? data.data : Array.isArray(data?.models) ? data.models : Array.isArray(data) ? data : [])
+      .map(model => ({
+        id: typeof model === 'string' ? model : (model.id || model.name || model.model || model.slug),
+        name: typeof model === 'string' ? model : (model.name || model.id || model.model || model.slug),
+      }))
+      .filter(m => m.id);
+  } else if (type === 'aliyun') {
+    // 阿里云百炼使用OpenAI兼容的API格式
+    const url = `${baseUrl}/models`;
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
       },
     });
 


### PR DESCRIPTION
增加了阿里云百炼作为模型服务提供商，便于给那些不方便使用OpenAI、Anthropic的cn大陆用户提供模型服务。

### 测试反馈：

1.**新建配置、编辑配置、导入配置、导出配置**均生效；

2.对于**新建配置、编辑配置**的其他细节部分，**加载可用模型**正常适配

3.对于**文本输入、文件上传、图片上传**的AI生成功能，均正常使用

### 部分测试图片反馈：

<img width="720" height="1141" alt="da520c3e30a3c278732f70d53295c06a" src="https://github.com/user-attachments/assets/bac3a956-7950-4fa4-8758-8f93d66af346" />
<img width="656" height="913" alt="4476f58ac7152db836ae17f9f539e0e1" src="https://github.com/user-attachments/assets/af121dd7-9045-44ae-be8d-f58075b31bed" />
<img width="993" height="769" alt="7fd71c8d6e0d78a8980f647da72dbfe6" src="https://github.com/user-attachments/assets/47385d8f-d27d-4177-aa02-4e408e1e7906" />
<img width="1291" height="1095" alt="3558ec66947f138671491297efafd929" src="https://github.com/user-attachments/assets/455d1096-df72-4af0-af5f-bef14f7d76df" />


关于具体改动细节(由AI根据提交记录生成)：
- 配置组件下拉列表新增阿里云百炼选项
- 支持阿里云百炼对应的API基地址占位符显示
- 验证逻辑允许阿里云百炼类型的配置
- LLM客户端新增调用阿里云百炼OpenAI兼容API的实现
- 支持阿里云百炼多模态内容消息的预处理
- 实现阿里云百炼模型列表的获取方法
- 处理API错误时返回详细的响应状态与内容信息

个人推荐使用**qwen3-max**模型，生成速度和质量均较为良好：）